### PR TITLE
Updated firstore listener slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ After cloning the repo, add an `.env` file in the root folder and define the fol
 API_ENDPOINT_AUTH = 
 API_ENDPOINT_LOGIN = 
 API_ENDPOINT_SIGNUP = 
+
+FIREBASE_CONFIG_apiKey = 
+FIREBASE_CONFIG_authDomain = 
+FIREBASE_CONFIG_databaseURL = 
+FIREBASE_CONFIG_projectId = 
+FIREBASE_CONFIG_storageBucket = 
+FIREBASE_CONFIG_messagingSenderId = 
+FIREBASE_CONFIG_appId = 
 ```
 
 ### Installation

--- a/src/configs/FirebaseConfig.ts
+++ b/src/configs/FirebaseConfig.ts
@@ -6,17 +6,17 @@ export interface IFirebaseConfig {
     databaseURL: string,
     storageBucket: string,
     messagingSenderId: string,
-    appId: string
+    appId: string,
 };
 
 /** Firebase Configuration */
 // TODO: Add this to .env
 export const FirebaseConfig: IFirebaseConfig = {
-    apiKey: "AIzaSyAuwWteY_G2oNeECTVat__bdBiKDG4wapA",
-    authDomain: "se-project-6d6d4.firebaseapp.com",
-    databaseURL: "https://se-project-6d6d4-default-rtdb.firebaseio.com",
-    projectId: "se-project-6d6d4",
-    storageBucket: "se-project-6d6d4.appspot.com",
-    messagingSenderId: "175833709354",
-    appId: "1:175833709354:web:2c735a14ab325cc73bbc53"
-  };
+    apiKey: process.env.FIREBASE_CONFIG_apiKey || '',
+    authDomain: process.env.FIREBASE_CONFIG_authDomain || '',
+    databaseURL: process.env.FIREBASE_CONFIG_databaseURL || '',
+    projectId: process.env.FIREBASE_CONFIG_projectId || '',
+    storageBucket: process.env.FIREBASE_CONFIG_storageBucket || '',
+    messagingSenderId: process.env.FIREBASE_CONFIG_messagingSenderId || '',
+    appId: process.env.FIREBASE_CONFIG_appId || ''
+}

--- a/src/contexts/DeviceContext.tsx
+++ b/src/contexts/DeviceContext.tsx
@@ -8,7 +8,7 @@ import { getFirestore, doc, onSnapshot, DocumentSnapshot} from "firebase/firesto
 
 /** Interface for Devices */
 export interface IDevice {
-    id: number,
+    id: string,
     state: {},
     type: string
 }
@@ -47,7 +47,12 @@ export const DeviceContextProvider: FC<{children: React.ReactElement}> = ({child
         const db = getFirestore();
         const ref = doc(db, `devices/${deviceId}`)
         onSnapshot(ref, (snap: DocumentSnapshot) => {
-                onUpdate(snap.data() as IDevice)
+                const device: IDevice = {
+                    id: deviceId,
+                    state: snap.data()?.state,
+                    type: snap.data()?.type
+                }
+                onUpdate(device)
             }
         )
     }


### PR DESCRIPTION
Updated firestore listener to work according to this discord post and added .env for firestore config:
```
The db structure is changing slightly.

When you're listening to the list of devices, each device object will no longer hold the id for itself. The device id will be found as the firestore id on each document.

This means you listen to the list of devices, get a list of documents, and the device id (that needs to be sent with actions etc) is the id on those firestore docs (accessible through .id or something similar depending on specific API).

Just be aware of this, as it means you can't directly translate the documents into Device objects, but you need to combine the "state" and "type" fields in the docs with the id of the doc itself.
```
![image](https://user-images.githubusercontent.com/48997798/223776577-09f91d79-32b5-4666-ab03-c43765a62a43.png)



